### PR TITLE
added signature to typing decorator

### DIFF
--- a/jaxtyping/decorator.py
+++ b/jaxtyping/decorator.py
@@ -28,6 +28,7 @@ storage = threading.local()
 class _Jaxtyped:
     def __init__(self, fn):
         self.fn = fn
+        self.__signature__ = inspect.signature(fn, follow_wrapped=True)
 
     def __get__(self, instance, owner):
         return ft.wraps(self.fn)(_Jaxtyped(self.fn.__get__(instance, owner)))


### PR DESCRIPTION
I figured out, the `_Jaxtyped` decorator misses the `__signature__` attribute. This then causes problems with [Haiku](https://github.com/deepmind/dm-haiku) later. Adding it in this simple way solved it for me and seems to be generally useful.