### PR TITLE
Fix _check_shape str formatting for variadics

### DIFF
--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -229,7 +229,7 @@ class _MetaAbstractArray(type):
             return _check_dims(cls.dims, obj.shape, single_memo, arg_memo)
         else:
             if obj.ndim < len(cls.dims) - 1:
-                return f"this array has {obj.ndim} dimensions, which is fewer than {len(cls.dims - 1)} that is the minimum expected by the type hint"  # noqa: E501
+                return f"this array has {obj.ndim} dimensions, which is fewer than {len(cls.dims) - 1} that is the minimum expected by the type hint"  # noqa: E501
             i = cls.index_variadic
             j = -(len(cls.dims) - i - 1)
             if j == 0:


### PR DESCRIPTION
`__instancecheck_str__` raises an exception from message formatting in a specific case of variadic shape mismatch.
This causes type checkers to raise exceptions, rather than properly type check, at runtime.

This is reproduced via:

```
import numpy as np

from jaxtyping import Shaped

ta = np.arange(3 * 10).reshape((3, 10))

# passes with true
isinstance(ta, Shaped[np.ndarray, "*p b c"])

# raises
isinstance(ta[0], Shaped[np.ndarray, "*p b c"])
```

for the error:
```
Traceback (most recent call last):
  File "/workspaces/jaxtyping/repro.py", line 11, in <module>
    isinstance(ta[0], Shaped[np.ndarray, "*p b c"])
  File "/workspaces/jaxtyping/jaxtyping/_array_types.py", line 156, in __instancecheck__
    return cls.__instancecheck_str__(obj) == ""
  File "/workspaces/jaxtyping/jaxtyping/_array_types.py", line 205, in __instancecheck_str__
    check = cls._check_shape(obj, single_memo, variadic_memo, arg_memo)
  File "/workspaces/jaxtyping/jaxtyping/_array_types.py", line 232, in _check_shape
    return f"this array has {obj.ndim} dimensions, which is fewer than {len(cls.dims - 1)} that is the minimum expected by the type hint"  # noqa: E501
TypeError: unsupported operand type(s) for -: 'tuple' and 'int'
```