### PR TITLE
Fix `jax` dependency issue when `jaxlib` is not installed.

### DIFF
--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -192,6 +192,7 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
     if (
         _tb_flag
         and importlib.util.find_spec("jax") is not None
+        and importlib.util.find_spec("jaxlib") is not None
         and importlib.util.find_spec("jax._src.traceback_util") is not None
     ):
         import jax._src.traceback_util as traceback_util


### PR DESCRIPTION
See https://github.com/patrick-kidger/jaxtyping/issues/188#issuecomment-1984247889.