### PR TITLE
Replace ndim with len(shape)

### DIFF
--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -224,12 +224,12 @@ class _MetaAbstractArray(type):
         arg_memo: dict[str, Any],
     ) -> str:
         if cls.index_variadic is None:
-            if obj.ndim != len(cls.dims):
-                return f"this array has {obj.ndim} dimensions, not the {len(cls.dims)} expected by the type hint"  # noqa: E501
+            if len(obj.shape) != len(cls.dims):
+                return f"this array has {len(obj.shape)} dimensions, not the {len(cls.dims)} expected by the type hint"  # noqa: E501
             return _check_dims(cls.dims, obj.shape, single_memo, arg_memo)
         else:
-            if obj.ndim < len(cls.dims) - 1:
-                return f"this array has {obj.ndim} dimensions, which is fewer than {len(cls.dims) - 1} that is the minimum expected by the type hint"  # noqa: E501
+            if len(obj.shape) < len(cls.dims) - 1:
+                return f"this array has {len(obj.shape)} dimensions, which is fewer than {len(cls.dims) - 1} that is the minimum expected by the type hint"  # noqa: E501
             i = cls.index_variadic
             j = -(len(cls.dims) - i - 1)
             if j == 0:


### PR DESCRIPTION
Hi!

I use `tensorflow==2.9.1` and I came across a situation where `tf.Tensor` could not have `ndim` attribute at some point of execution. Moreover, what I found out is that the problem does not occur in `tensorflow==2.16`. 
Here you have a simple code to reproduce the error. 

```
import tensorflow as tf
import jaxtyping as jax
import beartype

@tf.function()
@jax.jaxtyped(typechecker=beartype.beartype)
def map_function(tensor: jax.Float[tf.Tensor, "h w c"]) -> jax.Float[tf.Tensor, "h w c"]:
    return 1 - tensor

def main():

    tf.config.run_functions_eagerly(True)
    tf.data.experimental.enable_debug_mode()

    dataset = tf.data.Dataset.from_tensor_slices(tensors=tf.random.uniform((100,30,30,3)))
    dataset = dataset.map(map_function)

if __name__ == "__main__":

    main()
```

This is what i get
`AttributeError: 'Tensor' object has no attribute 'ndim'`

Unfortunately I'm pinned to the 2.9.1 version of `tensorflow`. Let me know what do you think.