### PR TITLE
Update deprecated method usage

### DIFF
--- a/test/test_no_jax_dependency.py
+++ b/test/test_no_jax_dependency.py
@@ -1,10 +1,12 @@
 import subprocess
 import sys
+import unittest
 
 
 _py_path = sys.executable
 
 
+@unittest.skipIf(not _py_path, "test requires sys.executable")
 def test_no_jax_dependency():
     result = subprocess.run(
         f"{_py_path} -c "
@@ -16,6 +18,7 @@ def test_no_jax_dependency():
 
 # Meta-test: test that the above test will work. (i.e. that I haven't messed up using
 # subprocess.)
+@unittest.skipIf(not _py_path, "test requires sys.executable")
 def test_meta():
     result = subprocess.run(
         f"{_py_path} -c 'import jaxtyping; import jax; import sys; "

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -54,7 +54,7 @@ def test_subscript(getkey, typecheck):
 
     g(1)
     g([1, 2, {"a": 3}])
-    g(jax.tree_map(lambda _: 1, make_mlp(getkey())))
+    g(jax.tree.map(lambda _: 1, make_mlp(getkey())))
 
     with pytest.raises(ParamError):
         g(object())


### PR DESCRIPTION
https://github.com/google/jax/pull/19930 deprecated `jax.tree_map` in favor of `jax.tree.map`.

Additionally, this adds some configuration to skip tests that depend on `sys.executable` in environments where it is not set.