### PR TITLE
typeguard warnings, on not having any annotations, now name the correct function.

### DIFF
--- a/test/test_array.py
+++ b/test/test_array.py
@@ -154,7 +154,7 @@ def test_any_dtype(jaxtyp, typecheck, getkey):
     g(jnp.array([[1, 2], [3, 4]], dtype=jnp.int8))
     g(jnp.array([[1, 2], [3, 4]], dtype=jnp.uint4))
     g(jnp.array([[1, 2], [3, 4]], dtype=jnp.uint16))
-    g(jr.normal(getkey(), (3, 4), dtype=jnp.complex128))
+    g(jr.normal(getkey(), (3, 4), dtype=jnp.complex64))
     g(jr.normal(getkey(), (3, 4), dtype=jnp.bfloat16))
 
     with pytest.raises(ParamError):

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -96,7 +96,7 @@ def test_context(getkey):
 
 def test_varargs(jaxtyp, typecheck):
     @jaxtyp(typecheck)
-    def f(*args):
+    def f(*args) -> None:
         pass
 
     f(1, 2)
@@ -104,7 +104,7 @@ def test_varargs(jaxtyp, typecheck):
 
 def test_varkwargs(jaxtyp, typecheck):
     @jaxtyp(typecheck)
-    def f(**kwargs):
+    def f(**kwargs) -> None:
         pass
 
     f(a=1, b=2)
@@ -112,7 +112,7 @@ def test_varkwargs(jaxtyp, typecheck):
 
 def test_defaults(jaxtyp, typecheck):
     @jaxtyp(typecheck)
-    def f(x: int, y=1):
+    def f(x: int, y=1) -> None:
         pass
 
     f(1)

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -20,7 +20,7 @@ def test_generators_simple(jaxtyp, typecheck):
         yield x
 
     @jaxtyp(typecheck)
-    def foo():
+    def foo() -> None:
         next(gen(jnp.zeros(2)))
         next(gen(jnp.zeros((3, 4))))
 
@@ -81,7 +81,7 @@ def test_generators_original_issue(jaxtyp, typecheck):
         yield x
 
     @jaxtyp(typecheck)
-    def f():
+    def f() -> None:
         next(g(torch.zeros(1)))
         next(g(torch.zeros(2)))
 


### PR DESCRIPTION
.