### PR TITLE
Improved localisation of errors to particular arguments.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.7
     hooks:
+      - id: ruff-format  # formatter
+        types_or: [ python, pyi, jupyter ]
       - id: ruff  # linter
         types_or: [ python, pyi, jupyter ]
         args: [ --fix ]
-      - id: ruff-format  # formatter
-        types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
This commit does two things.

First of all, it fixes a bug in which we forgot to add in default arguments when calling `_get_problem_arg`. This meant that in practice, if you had a default argument, then the very first argument would be what is reported.

Second, it rearranges things into a couple of extra stack frames, for an easier debugging experience.
- When looking at the main error message, this will now occur on the line that actually raised it, and not the `finally: pop_stack_memo()` line.
- The argument-specific `_get_problem_arg` error is what is now attached as the cause, rather than the overall failure of the whole typechecking.