### PR TITLE
Replace `ast.Str` with `ast.Constant` (deprecation warning raised in python 3.12)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Now make your changes. Make sure to include additional tests if necessary.
 Next verify the tests all pass:
 
 ```bash
-pip install pytest cloudpickle
+pip install -r test/requirements.txt
 pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
 pytest
 ```

--- a/jaxtyping/_import_hook.py
+++ b/jaxtyping/_import_hook.py
@@ -144,7 +144,7 @@ class JaxtypingTransformer(ast.NodeVisitor):
         for i, child in enumerate(node.body):
             if isinstance(child, ast.ImportFrom) and child.module == "__future__":
                 continue
-            elif isinstance(child, ast.Expr) and isinstance(child.value, ast.Str):
+            elif isinstance(child, ast.Expr) and isinstance(child.value, ast.Constant):
                 continue  # module docstring
             else:
                 node.body.insert(i, ast.Import(names=[ast.alias("jaxtyping", None)]))

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,7 @@ beartype
 cloudpickle
 equinox
 IPython
-jaxlib
+jax
 pytest
 pytest-asyncio
 tensorflow


### PR DESCRIPTION
Also updated `CONTRIBUTING.md` to install the test requirements file, and replaced `jaxlib` with `jax` in that requirements file since they're bundled together now (+ `jax` isn't necessarily installed in the env for `jaxtyping` to work, but is needed for tests).