### PR TITLE
Fix issue with no props available to _get_props() for __eq__() and __hash__() on depickling

### DIFF
--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -322,11 +322,11 @@ def _make_metaclass(base_metaclass):
     class MetaAbstractArray(_MetaAbstractArray, base_metaclass):
         def _get_props(cls):
             props_tuple = (
-                cls.index_variadic,
-                cls.dims,
-                cls.array_type,
-                cls.dtypes,
-                cls.dim_str,
+                getattr(cls, "index_variadic", None),
+                getattr(cls, "dims", None),
+                getattr(cls, "array_type", None),
+                getattr(cls, "dtypes", None),
+                getattr(cls, "dim_str", None),
             )
             return props_tuple
 
@@ -337,9 +337,7 @@ def _make_metaclass(base_metaclass):
             return cls._get_props() == other._get_props()
 
         def __hash__(cls):
-            # Does not use `_get_props` as these attributes don't necessarily exist
-            # during depickling. See #198.
-            return 0
+            return hash(cls._get_props())
 
     return MetaAbstractArray
 


### PR DESCRIPTION
As described in #198 and changed in #237, the `_get_props()` method can fail on depickling because some of the array attributes might not exist.

A fix in #237 only partially resolved the issue, and only for `__hash__()` operation.

In this PR, I offer a different approach: instead of modifying the op function `__eq__()` (that was broken with the same `has no attribute 'index_variadic'` message in our case), we update `_get_props()` method not to fail if certain attributes are missing.