### PR TITLE
Allow Python versions higher than 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "jaxtyping"
 version = "0.2.34"
 description = "Type annotations and runtime checking for shape and dtype of JAX arrays, and PyTrees."
 readme = "README.md"
-requires-python ="~=3.9"
+requires-python =">=3.9"
 license = {file = "LICENSE"}
 authors = [
   {name = "Patrick Kidger", email = "contact@kidger.site"},


### PR DESCRIPTION
It is currently impossible to add jaxtyping to a modern Python project using Poetry, because the current pyproject.toml says that it only supports Python 3.9

This PR fixes this