### PR TITLE
Call typechecker from isolated frame

### DIFF
--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -57,6 +57,10 @@ _sentinel = _Sentinel()
 _tb_flag = True
 
 
+def _apply_typechecker(typechecker, fn):
+    return typechecker(fn)
+
+
 @overload
 def jaxtyped(
     *,
@@ -422,8 +426,8 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
             param_fn = _make_fn_with_signature(
                 name, qualname, module, param_signature, output=False
             )
-            full_fn = typechecker(full_fn)
-            param_fn = typechecker(param_fn)
+            full_fn = _apply_typechecker(typechecker, full_fn)
+            param_fn = _apply_typechecker(typechecker, param_fn)
 
             def wrapped_fn_impl(args, kwargs, bound, memos):
                 # First type-check just the parameters before the function is
@@ -790,7 +794,9 @@ def _get_problem_arg(
         fn = _make_fn_with_signature(
             "check_single_arg", "check_single_arg", module, new_signature, output=False
         )
-        fn = typechecker(fn)  # but no `jaxtyped`; keep the same environment.
+        fn = _apply_typechecker(
+            typechecker, fn
+        )  # but no `jaxtyped`; keep the same environment.
         try:
             fn(*args, **kwargs)
         except Exception as e:

--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -58,7 +58,7 @@ _tb_flag = True
 
 
 def _apply_typechecker(typechecker, fn):
-    """Calls `typechecker(fn)` in an isolated frame.
+    """Calls `typechecker(fn)` in an isolated frame, returning the result.
 
     This avoids reference cycles that can otherwise occur if `typechecker` grabs
     the calling frame's locals.

--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -58,6 +58,11 @@ _tb_flag = True
 
 
 def _apply_typechecker(typechecker, fn):
+    """Calls `typechecker(fn)` in an isolated frame.
+
+    This avoids reference cycles that can otherwise occur if `typechecker` grabs
+    the calling frame's locals.
+    """
     return typechecker(fn)
 
 

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+import sys
 from typing import no_type_check
 
 import jax.numpy as jnp
@@ -231,6 +232,31 @@ def test_no_garbage_identity_typecheck():
     with assert_no_garbage():
 
         @jaxtyped(typechecker=lambda x: x)
+        @dataclasses.dataclass
+        class _Obj:
+            x: int
+
+        _Obj(x=5)
+
+
+def test_no_garbage_frame_capture_typecheck():
+    with assert_no_garbage():
+        # Some typechecker implementations (e.g., typeguard 2.13.3) capture the calling
+        # frame's f_locals. This test checks that the calling frames in jaxtyping are
+        # sufficiently isolated to avoid introducing reference cycles when a
+        # typechecker does this.
+        def frame_locals_capture(fn):
+            locals = sys._getframe(1).f_locals
+
+            def wrapper(*args, **kwargs):
+                # Required to ensure wrapper holds a reference to f_locals, which is
+                # the scenario under test.
+                _ = locals
+                return fn(*args, **kwargs)
+
+            return wrapper
+
+        @jaxtyped(typechecker=frame_locals_capture)
         @dataclasses.dataclass
         class _Obj:
             x: int

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -6,7 +6,6 @@ from typing import no_type_check
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
-import typeguard
 
 from jaxtyping import Array, Float, jaxtyped, print_bindings
 
@@ -214,10 +213,6 @@ def test_no_type_check(typecheck):
 
 
 def test_no_garbage(typecheck):
-    if typecheck is typeguard.typechecked:
-        # Currently fails due to reference cycles in typeguard.
-        pytest.skip()
-
     with assert_no_garbage():
 
         @jaxtyped(typechecker=typecheck)


### PR DESCRIPTION
The version of TypeGuard that JaxTyping depends on grabs the calling frame's locals using `sys._getframe(1).f_locals`, and returns a wrapping function that holds a reference to these locals. JaxTyping currently calls the typechecker from a frame that contains some locals. Of these, `full_fn` and `param_fn` are problematic because they, in combination with what TypeGuard is doing, end up creating reference cycles.

This commit calls the typechecker from an isolated frame in JaxTyping. This means `f_locals` of the calling frame doesn't contain anything that can end up creating cycles.

It's somewhat debatable whether this should be considered a TypeGuard problem, but I think it would be tricky to fix there. TypeGuard appears to need a mutable version of the locals to see forward defined variables, so it's not viable just to copy them and remove anything that's problematic. Even if it were, TypeGuard doesn't really know which locals are problematic and not required. So pragmatically, changing JaxTyping to guard against the issue feels like the correct thing to do.