### PR TITLE
Add typing_extensions to allow usage of ParamSpec in python < 3.10

### DIFF
--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -33,9 +33,16 @@ from typing import (
     get_type_hints,
     NoReturn,
     overload,
-    ParamSpec,
     TypeVar,
 )
+
+
+try:
+    from typing import ParamSpec
+except ImportError:
+    # Python < 3.10
+    from typing_extensions import ParamSpec
+
 
 from jaxtyping import AbstractArray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/google/jaxtyping" }
-dependencies = []
+dependencies = [
+  "typing_extensions; python_version < '3.10'"
+]
 entry-points = {pytest11 = {jaxtyping = "jaxtyping._pytest_plugin"}}
 
 [build-system]


### PR DESCRIPTION
Fixes #269 using the `typing_extensions` backport.