### PR TITLE
Scalarlike now just goes by its name in equinox ecosystem documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 site/
 .all_objects.cache
+.venv

--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -198,9 +198,18 @@ else:
 
                 return Shaped[jax.Array, ""]
             elif item == "ScalarLike":
-                import jax.typing
+                if getattr(typing, "GENERATING_DOCUMENTATION", False):
 
-                return Shaped[jax.typing.ArrayLike, ""]
+                    class ScalarLike:
+                        pass
+
+                    ScalarLike.__module__ = "builtins"
+                    ScalarLike.__qualname__ = "ScalarLike"
+                    return ScalarLike
+                else:
+                    import jax.typing
+
+                    return jax.typing.ArrayLike
             elif item == "PyTree":
                 from ._pytree_type import PyTree
 

--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -209,7 +209,7 @@ else:
                 else:
                     import jax.typing
 
-                    return jax.typing.ArrayLike
+                    return Shaped[jax.typing.ArrayLike, ""]
             elif item == "PyTree":
                 from ._pytree_type import PyTree
 


### PR DESCRIPTION
As suggested in https://github.com/patrick-kidger/optimistix/pull/109. 

I built the optimistix documentation with jaxtyping from this branch, and it works splendidly.