### PR TITLE
Fix equinox version string parsing to ignore local version if it exis…

### DIFF
--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -22,6 +22,7 @@ import importlib.metadata
 import typing
 import warnings
 from typing import TypeAlias, Union
+import re
 
 from ._array_types import (
     AbstractArray as AbstractArray,
@@ -225,7 +226,7 @@ if check_equinox_version:
     except importlib.metadata.PackageNotFoundError:
         pass
     else:
-        major, minor, patch = eqx_version.split(".")
+        major, minor, patch, _ = re.split(r'[.+]', eqx_version)
         equinox_version = (int(major), int(minor), int(patch))
         if equinox_version < (0, 11, 0):
             warnings.warn(


### PR DESCRIPTION
…ts instead of crashing.

This avoids crashing like:
```
(eqENV) [c7wilson@gra-login2 ~]$ python -c "from jaxtyping import PyTree"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/c7wilson/eqENV/lib/python3.12/site-packages/jaxtyping/__init__.py", line 229, in <module>
    equinox_version = (int(major), int(minor), int(patch))
                                               ^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '9+computecanada'
```

