### PR TITLE
Guard against implicit dependency on numpy if it is not imported

### DIFF
--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -37,6 +37,14 @@ from typing import (
     Union,
 )
 
+from ._errors import AnnotationError
+from ._storage import (
+    get_shape_memo,
+    get_treeflatten_memo,
+    get_treepath_memo,
+    set_shape_memo,
+)
+
 
 # Bit of a hack, but jaxtyping provides nicer error messages than typeguard. This means
 # we sometimes want to use it as our runtime type checker everywhere, even in non-array
@@ -50,14 +58,6 @@ IS_NUMPY_INSTALLED = importlib.util.find_spec("numpy") is not None
 if IS_NUMPY_INSTALLED:
     import numpy as np
     import numpy.typing as npt
-
-from ._errors import AnnotationError
-from ._storage import (
-    get_shape_memo,
-    get_treeflatten_memo,
-    get_treepath_memo,
-    set_shape_memo,
-)
 
 
 _array_name_format = "dtype_and_shape"
@@ -845,6 +845,10 @@ def make_numpy_struct_dtype(dtype: "np.dtype", name: str):
     A type annotation with classname `name` that matches exactly `dtype` when used like
     any other [`jaxtyping.AbstractDtype`][].
     """
-    if not (IS_NUMPY_INSTALLED and isinstance(dtype, np.dtype) and _dtype_is_numpy_struct_array(dtype)):
+    if not (
+        IS_NUMPY_INSTALLED
+        and isinstance(dtype, np.dtype)
+        and _dtype_is_numpy_struct_array(dtype)
+    ):
         raise ValueError(f"Expecting a numpy structured array dtype, not {dtype}")
     return _make_dtype(str(dtype), name)


### PR DESCRIPTION
https://github.com/patrick-kidger/jaxtyping/issues/360

### Context
I'm using it in conjunction with Array API compatible functions to get shape/type-checking for generic arrays. (side-note: eventually hoping that https://github.com/data-apis/array-api-typing gets more ready, but for now just creating some `Protocol` types as stubs for true array types).

While debugging another issue in my library, I noticed that `numpy` is implicitly required, but is not an explicit dependency. 

```
(mach-beamform) user@245e0f32-bf2b-4f2a-b28f-a9c83c582fa2:~/mach$ uvx --with mach-beamform --with pip --python 3.12 python -c "import mach"
Installed 6 packages in 32ms
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/user/.cache/uv/archive-v0/FmuhqtL7VDFxV1NtVg6_B/lib/python3.12/site-packages/mach/__init__.py", line 17, in <module>
    from . import geometry, kernel, wavefront
  File "/home/user/.cache/uv/archive-v0/FmuhqtL7VDFxV1NtVg6_B/lib/python3.12/site-packages/mach/geometry.py", line 32, in <module>
    azimuth_rad: Union[Real[Array, " *angles"], float, int],
                       ~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/user/.cache/uv/archive-v0/FmuhqtL7VDFxV1NtVg6_B/lib/python3.12/site-packages/jaxtyping/_array_types.py", line 668, in __getitem__
    out = _make_array(array_type, dim_str, cls)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.cache/uv/archive-v0/FmuhqtL7VDFxV1NtVg6_B/lib/python3.12/site-packages/jaxtyping/_array_types.py", line 601, in _make_array
    out = _make_array_cached(x, dim_str, dtype.dtypes, dtype.__name__)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.cache/uv/archive-v0/FmuhqtL7VDFxV1NtVg6_B/lib/python3.12/site-packages/jaxtyping/_array_types.py", line 554, in _make_array_cached
    elif array_type is np.bool_:
                       ^^
NameError: name 'np' is not defined
```

### Changes
Guard all `np` or `npt` usage with a `IS_NUMPY_INSTALLED` flag.


### Testing
Two tests fail, but they seem unrelated to this change.

```
jaxtyping on  360-numpy-dep is 📦 v0.3.3 via 🐍 v3.11.13 on ☁️   
at 09:05:23 ❌2 ❯ uv run --python 3.12 --extra tests pytest
Using CPython 3.12.12
Removed virtual environment at: .venv
Creating virtual environment at: .venv
Installed 68 packages in 217ms
============================================================ test session starts =============================================================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/cguan/Development/jaxtyping
configfile: pyproject.toml
plugins: jaxtyping-0.3.3, asyncio-1.3.0, typeguard-2.13.3
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 282 items                                                                                                                          

test/test_all_importable.py .                                                                                                          [  0%]
test/test_array.py ................................................................................................................... [ 41%]
............                                                                                                                           [ 45%]
test/test_decorator.py ...............................................                                                                 [ 62%]
test/test_generators.py .F...F..........ssss                                                                                           [ 69%]
test/test_import_hook.py .......                                                                                                       [ 71%]
test/test_ipython_extension.py .......                                                                                                 [ 74%]
test/test_messages.py ......                                                                                                           [ 76%]
test/test_no_jax_dependency.py ..                                                                                                      [ 76%]
test/test_pytree.py .............................................................                                                      [ 98%]
test/test_serialisation.py .                                                                                                           [ 98%]
test/test_tf_dtype.py .                                                                                                                [ 99%]
test/test_threading.py ..                                                                                                              [100%]

================================================================== FAILURES ==================================================================
___________________________________________________ test_generators_simple[False-beartype] ___________________________________________________

jaxtyp = <function jaxtyp.<locals>.impl at 0x366a17a60>, typecheck = <function beartype at 0x133452160>

    def test_generators_simple(jaxtyp, typecheck):
        @jaxtyp(typecheck)
        def gen(x: Float[Array, "*"]) -> Iterator[Float[Array, "*"]]:
            yield x
    
        @jaxtyp(typecheck)
        def foo() -> None:
            next(gen(jnp.zeros(2)))
            next(gen(jnp.zeros((3, 4))))
    
>       foo()

test/test_generators.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
<@beartype(test.test_generators.test_generators_simple.foo) at 0x366a17ec0>:12: in foo
    ???
test/test_generators.py:25: in foo
    next(gen(jnp.zeros((3, 4))))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

__beartype_object_14538054480 = <class 'jaxtyping.Float[Array, '*']'>
__beartype_get_violation = <function get_func_pith_violation at 0x13375b2e0>, __beartype_conf = BeartypeConf()
__beartype_object_4620098256 = <class 'collections.abc.Iterator'>
__beartype_check_meta = <beartype._check.metadata.metacheck.BeartypeCheckMeta object at 0x36627cb40>
__beartype_func = <function test_generators_simple.<locals>.gen at 0x366a17ce0>
args = (Array([[0., 0., 0., 0.],
       [0., 0., 0., 0.],
       [0., 0., 0., 0.]], dtype=float32),), kwargs = {}, __beartype_args_len = 1
__beartype_pith_0 = Array([[0., 0., 0., 0.],
       [0., 0., 0., 0.],
       [0., 0., 0., 0.]], dtype=float32)
__beartype_violation = BeartypeCallHintParamViolation('Generator factory function test.test_generators.test_generators_simple.gen() parameter...xisting value of (2,).', (Array([[0., 0., 0., 0.],
       [0., 0., 0., 0.],
       [0., 0., 0., 0.]], dtype=float32),))

>   ???
E   beartype.roar.BeartypeCallHintParamViolation: Generator factory function test.test_generators.test_generators_simple.gen() parameter x="Array([[0., 0., 0., 0.],
E          [0., 0., 0., 0.],
E          [0., 0., 0., 0.]], dtype=float32)" violates type hint <class 'jaxtyping.Float[Array, '*']'>, as the shape of its variadic dimensions '*' is (3, 4), which does not equal the existing value of (2,).
E   --------------------
E   The preceding error occurred within the scope of a `jaxtyping.jaxtyped` function, and may be due to a typecheck error. The current values for each jaxtyping axis annotation are as follows.
E   =(2,)

<@beartype(test.test_generators.test_generators_simple.gen) at 0x366a17ce0>:30: BeartypeCallHintParamViolation
___________________________________________ test_generators_return_no_annotations[False-beartype] ____________________________________________

jaxtyp = <function jaxtyp.<locals>.impl at 0x366a8bc40>, typecheck = <function beartype at 0x133452160>

    def test_generators_return_no_annotations(jaxtyp, typecheck):
        @jaxtyp(typecheck)
        def gen(x: Float[Array, "*"]):
            yield x
    
        @jaxtyp(typecheck)
        def foo():
            next(gen(jnp.zeros(2)))
            next(gen(jnp.zeros((3, 4))))
    
>       foo()

test/test_generators.py:40: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test/test_generators.py:38: in foo
    next(gen(jnp.zeros((3, 4))))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

__beartype_object_5156931280 = <class 'jaxtyping.Float[Array, '*']'>
__beartype_get_violation = <function get_func_pith_violation at 0x13375b2e0>, __beartype_conf = BeartypeConf()
__beartype_check_meta = <beartype._check.metadata.metacheck.BeartypeCheckMeta object at 0x366a97480>
__beartype_func = <function test_generators_return_no_annotations.<locals>.gen at 0x366a8ba60>
args = (Array([[0., 0., 0., 0.],
       [0., 0., 0., 0.],
       [0., 0., 0., 0.]], dtype=float32),), kwargs = {}, __beartype_args_len = 1
__beartype_pith_0 = Array([[0., 0., 0., 0.],
       [0., 0., 0., 0.],
       [0., 0., 0., 0.]], dtype=float32)
__beartype_violation = BeartypeCallHintParamViolation('Generator factory function test.test_generators.test_generators_return_no_annotations....xisting value of (2,).', (Array([[0., 0., 0., 0.],
       [0., 0., 0., 0.],
       [0., 0., 0., 0.]], dtype=float32),))

>   ???
E   beartype.roar.BeartypeCallHintParamViolation: Generator factory function test.test_generators.test_generators_return_no_annotations.gen() parameter x="Array([[0., 0., 0., 0.],
E          [0., 0., 0., 0.],
E          [0., 0., 0., 0.]], dtype=float32)" violates type hint <class 'jaxtyping.Float[Array, '*']'>, as the shape of its variadic dimensions '*' is (3, 4), which does not equal the existing value of (2,).
E   --------------------
E   The preceding error occurred within the scope of a `jaxtyping.jaxtyped` function, and may be due to a typecheck error. The current values for each jaxtyping axis annotation are as follows.
E   =(2,)

<@beartype(test.test_generators.test_generators_return_no_annotations.gen) at 0x366a8ba60>:29: BeartypeCallHintParamViolation
============================================================== warnings summary ==============================================================
test/test_generators.py::test_generators_return_no_annotations[False-typechecked]
  /Users/cguan/Development/jaxtyping/.venv/lib/python3.12/site-packages/typeguard/__init__.py:1016: UserWarning: no type annotations present -- not typechecking test.test_generators.test_generators_return_no_annotations.<locals>.foo
    warn('no type annotations present -- not typechecking {}'.format(function_name(func)))

test/test_generators.py::test_async_generators_simple[False-typechecked]
  /Users/cguan/Development/jaxtyping/.venv/lib/python3.12/site-packages/typeguard/__init__.py:1016: UserWarning: no type annotations present -- not typechecking test.test_generators.test_async_generators_simple.<locals>.foo
    warn('no type annotations present -- not typechecking {}'.format(function_name(func)))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== short test summary info ===========================================================
FAILED test/test_generators.py::test_generators_simple[False-beartype] - beartype.roar.BeartypeCallHintParamViolation: Generator factory function test.test_generators.test_generators_simple.gen() parameter x="A...
FAILED test/test_generators.py::test_generators_return_no_annotations[False-beartype] - beartype.roar.BeartypeCallHintParamViolation: Generator factory function test.test_generators.test_generators_return_no_annotations.gen()...
=========================================== 2 failed, 276 passed, 4 skipped, 2 warnings in 24.60s ============================================

```