### PR TITLE
fix(pytest_plugin): avoid splitting typechecker constructor with commas

### DIFF
--- a/jaxtyping/_pytest_plugin.py
+++ b/jaxtyping/_pytest_plugin.py
@@ -39,7 +39,13 @@ def pytest_configure(config):
     if not value:
         return
 
-    packages = [pkg.strip() for pkg in value.split(",")]
+    maxsplit = -1
+    # We avoid splitting on commas inside of the typechecker constructor
+    # (e.g. `beartype.beartype(option_a=..., option_b=...)`)
+    if index := value.find("(") != -1:
+        maxsplit = value[:index].count(",") + 1
+
+    packages = [pkg.strip() for pkg in value.split(",", maxsplit=maxsplit)]
     *packages, typechecker = packages
 
     already_imported_packages = sorted(


### PR DESCRIPTION
Hi!

When trying to configure the typechecker via Pytest options, I noticed that an internal error would be raised as soon as the typechecker constructor contains a comma `,`, because the string is split on every comma, including those inside the call.

There are many ways to fix this, but I found that looking for the presence of `(` and, if present, reducing the maximum number of splits to avoid truncating the typechecker instantiation would work just fine.

E.g.,

```
--jaxtyping-packages=foopackage,barpackage,typeguard.typechecked
--jaxtyping-packages=differt,beartype.beartype(conf=beartype.BeartypeConf(strategy=beartype.BeartypeStrategy.On))"
--jaxtyping-packages=differt,beartype.beartype(conf=beartype.BeartypeConf(strategy=beartype.BeartypeStrategy.On,))"
--jaxtyping-packages=differt,beartype.beartype(conf=beartype.BeartypeConf(strategy=beartype.BeartypeStrategy.On,hint_overrides=beartype.BeartypeHintOverrides({threading.RLock: object)))
```

will now all work correctly.
