### PR TITLE
fix(pytest): execute import hook before `conftest.py` files are read

### DIFF
--- a/jaxtyping/_pytest_plugin.py
+++ b/jaxtyping/_pytest_plugin.py
@@ -34,8 +34,12 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
-    value = config.getoption("jaxtyping_packages")
+def pytest_load_initial_conftests(early_config, parser, args):
+    # We run this function before conftest.py files are loaded,
+    # so we can instrument imports before any code is run.
+    del early_config
+    options = parser.parse_known_args(args)
+    value = options.jaxtyping_packages
     if not value:
         return
 


### PR DESCRIPTION
Hello!

This comes a bit out of nowhere, but I had this bug for a long time where running `pytest` on specific paths (instead of the plain `pytest` command) would raise an error because my package would already be imported, before the import hook could be run.

After some research, I found that the issue originates from my `contest.py` files, which import the package under test to create fixtures.

Apparently, this issue can be fixed by changing how your plugin is run, i.e., by evaluating it during the initial phase. I looked at other projects, and this seems to be a common practice.

Here is a small patch for this purpose :-)

You can verify that it works by adding `import equinox` to `equinox/tests/conftest.py` and then running `pytest`.