### PR TITLE
Add `assert_jaxtype` function.

### DIFF
--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -30,6 +30,7 @@ from ._array_types import (
     make_numpy_struct_dtype as make_numpy_struct_dtype,
     set_array_name_format as set_array_name_format,
 )
+from ._assertions import assert_jaxtype as assert_jaxtype
 from ._config import config as config
 from ._decorator import jaxtyped as jaxtyped
 from ._errors import (

--- a/jaxtyping/_assertions.py
+++ b/jaxtyping/_assertions.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 Google LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from typing import assert_type, TYPE_CHECKING
+
+from jax import Array
+
+
+def _assert_jaxtype(x, jaxtype):
+    """Asserts that a value has the desired jaxtyping type and returns it.
+
+    Raises an `AssertionError` if the input does not match.
+
+    **Arguments:**
+
+    - `x`: The value to validate.
+    - `jaxtype`: The jaxtyping annotation to check against.
+
+    **Returns:**
+
+    The input value `x`, unchanged.
+    """
+    __tracebackhide__ = True
+    if isinstance(x, Array):
+        instance_repr = f"Array(shape={x.shape}, dtype={x.dtype})"
+    else:
+        instance_repr = x
+    assert isinstance(x, jaxtype), (
+        f"Instance {instance_repr} does not match JAX type {jaxtype}."
+    )
+    return x
+
+
+if TYPE_CHECKING:
+    assert_jaxtype = assert_type
+else:
+    assert_jaxtype = _assert_jaxtype

--- a/test/test_assertions.py
+++ b/test/test_assertions.py
@@ -1,0 +1,42 @@
+import jax.numpy as jnp
+import pytest
+
+from jaxtyping import Array, assert_jaxtype, Float, Float32, Int
+
+
+def test_assert_jaxtype_success():
+    x = jnp.empty((3, 4), dtype=jnp.float32)
+    result = assert_jaxtype(x, Float32[Array, "3 4"])
+    assert result is x
+
+
+def test_assert_jaxtype_wrong_shape():
+    x = jnp.empty((3, 4), dtype=jnp.float32)
+    with pytest.raises(AssertionError, match="does not match"):
+        assert_jaxtype(x, Float32[Array, "5 6"])
+
+
+def test_assert_jaxtype_wrong_dtype():
+    x = jnp.empty((3, 4), dtype=jnp.float32)
+    with pytest.raises(AssertionError, match="does not match"):
+        assert_jaxtype(x, Int[Array, "3 4"])
+
+
+def test_assert_jaxtype_symbolic_shape():
+    x = jnp.empty((3, 4), dtype=jnp.float32)
+    result = assert_jaxtype(x, Float[Array, "batch dim"])
+    assert result is x
+
+
+def test_assert_jaxtype_any_shape():
+    x = jnp.empty((3, 4, 5), dtype=jnp.float32)
+    result = assert_jaxtype(x, Float[Array, "..."])
+    assert result is x
+
+
+def test_assert_jaxtype_error_message_contains_shape_and_dtype():
+    x = jnp.empty((3, 4), dtype=jnp.float32)
+    with pytest.raises(AssertionError, match=r"shape=\(3, 4\)"):
+        assert_jaxtype(x, Int[Array, "3 4"])
+    with pytest.raises(AssertionError, match=r"dtype=float32"):
+        assert_jaxtype(x, Int[Array, "3 4"])


### PR DESCRIPTION
This PR adds a function `assert_jaxtype` that defaults to `assert_type` during `TYPE_CHECKING` and runs an `isinstance` check at runtime. The motivation is to support static type inference and runtime checking in one go. E.g., the example below will correctly resolve types (at least in pyright) and also runs the instance check.

```python
from jax import Array
from jaxtyping import assert_jaxtype, Float 


x = assert_jaxtype(some_array, Float[Array, "batch_size num_features"])
```

I don't quite know whether this fits with your design philosophy because runtime checks are currently delegated to external libraries. I found the little helper quite useful, however.