### PR TITLE
Add pyrefly as a type checker in pre-commit and dev dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,10 @@ repos:
         language: system
         entry: uv run -- mypy --ignore-missing-imports --follow-imports=skip
         require_serial: true
+      - id: pyrefly
+        name: pyrefly
+        files: ^test/types/
+        types_or: [python]
+        language: system
+        entry: uv run -- pyrefly check
+        require_serial: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = ["hatchling"]
 dev = [
   "mypy==1.14.1",
   "prek==0.3.9",
+  "pyrefly==0.62.0",
   "pyright==1.1.391",
   "ruff==0.13.0",
   "toml-sort==0.23.1"


### PR DESCRIPTION
Summary

- Adds https://github.com/facebook/pyrefly (v0.62.0) as a third type checker alongside pyright and mypy, scoped to test/types/
- Adds pyrefly to the dev dependency group in pyproject.toml
- Adds a pyrefly pre-commit hook in .pre-commit-config.yaml

Motivation

Pyrefly is a new Rust-based Python type checker from Meta. Benchmarking against the existing checkers on test/types/ shows significant speed improvements:

| Checker | Avg (5 runs) |
|---------|-------------|
| mypy (cold) | 5.34s |
| mypy (warm) | 0.41s |
| pyright | 0.48s |
| pyrefly | 0.18s |


All existing hooks continue to pass. Pyrefly runs cleanly on test/types/ with no configuration needed.

Test plan

- uv run pyrefly check test/types/ - 0 errors
- uv run prek run --all-files - all 11 hooks pass (including new pyrefly hook)
- Benchmarked 5 cold/warm runs per checker to confirm performance numbers