### PR TITLE
Make _array_types sentinels survive cloudpickle round-trip.

### DIFF
--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -33,6 +33,7 @@ from typing import (
     Literal,
     NoReturn,
     Optional,
+    Self,
     TypeVar,
     Union,
 )
@@ -80,10 +81,60 @@ def set_array_name_format(value):
     _array_name_format = value
 
 
-_any_dtype = object()
+# These three module-level sentinels are stored on persisted jaxtyping types
+# (`cls.dtypes`, `cls.dims`), so they must survive a pickle round-trip with their
+# identity intact: downstream code uses `is`-checks against them. A bare
+# `object()` does not. E.g., `cloudpickle` serialises an unrelated instance by value
+# on the receiving side, breaking the `is`-check. Each sentinel is therefore a
+# `__reduce__`-backed singleton class with one live instance per process.
 
-_anonymous_dim = object()
-_anonymous_variadic_dim = object()
+
+class _AnyDtype:
+    """Picklable singleton sentinel for the "any dtype" marker."""
+
+    _instance: Self | None = None
+
+    def __new__(cls) -> Self:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __reduce__(self) -> tuple[type["_AnyDtype"], tuple[()]]:
+        return (_AnyDtype, ())
+
+
+class _AnonymousDim:
+    """Picklable singleton sentinel for the anonymous `_` axis marker."""
+
+    _instance: Self | None = None
+
+    def __new__(cls) -> Self:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __reduce__(self) -> tuple[type["_AnonymousDim"], tuple[()]]:
+        return (_AnonymousDim, ())
+
+
+class _AnonymousVariadicDim:
+    """Picklable singleton sentinel for the variadic `"..."` axis marker."""
+
+    _instance: Self | None = None
+
+    def __new__(cls) -> Self:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __reduce__(self) -> tuple[type["_AnonymousVariadicDim"], tuple[()]]:
+        return (_AnonymousVariadicDim, ())
+
+
+_any_dtype = _AnyDtype()
+
+_anonymous_dim = _AnonymousDim()
+_anonymous_variadic_dim = _AnonymousVariadicDim()
 
 
 class _DimType(enum.Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ name = "jaxtyping"
 readme = "README.md"
 requires-python = ">=3.11"
 urls = {repository = "https://github.com/patrick-kidger/jaxtyping"}
-version = "0.3.9"
+version = "0.3.10"
 
 [tool.hatch.build]
 include = ["jaxtyping/*"]

--- a/test/test_serialisation.py
+++ b/test/test_serialisation.py
@@ -33,3 +33,27 @@ def test_pickle():
             y = p.loads(x)
             assert y.dtype is Float
             assert y.dim_str == "batch length"
+
+
+# The three regression tests below pin down that the module-level sentinels in
+# `_array_types` survive pickle/cloudpickle round-trips with their identity intact. Each
+# test does an `isinstance` check after the round-trip. That is the call path tripping
+# the bug described in #390.
+
+
+def test_pickle_any_dtype():
+    for p in (pickle, cloudpickle):
+        loaded = p.loads(p.dumps(Shaped[np.ndarray, "2 3"]))
+        assert isinstance(np.zeros((2, 3)), loaded)
+
+
+def test_pickle_anonymous_dim():
+    for p in (pickle, cloudpickle):
+        loaded = p.loads(p.dumps(Float[np.ndarray, "_ _"]))
+        assert isinstance(np.zeros((2, 3)), loaded)
+
+
+def test_pickle_anonymous_variadic_dim():
+    for p in (pickle, cloudpickle):
+        loaded = p.loads(p.dumps(Float[np.ndarray, "..."]))
+        assert isinstance(np.zeros((2, 3)), loaded)


### PR DESCRIPTION
The three module-level `object()` sentinels in `_array_types` (`_any_dtype`, `_anonymous_dim`, `_anonymous_variadic_dim`) are stored on persisted jaxtyping types (`cls.dtypes`, `cls.dims`). cloudpickle serialises them by value, so on the receiving side they are fresh `object()` instances that no longer match the live module-global sentinel — breaking `is`-checks that downstream shape-check code relies on. The symptom for `_anonymous_variadic_dim` is an `AssertionError` in `_check_dims`; the other two sentinels fail similarly when isinstance() runs against a cloudpickled type.

Replace each with a `__reduce__`-backed singleton class. The fourth `object()` sentinel in this file, `_not_made`, is transient factory output filtered before any type is built, so it doesn't suffer the same bug and is left alone.

Three regression tests added in `test_serialisation.py`, one per sentinel, each round-tripping under both `pickle` and `cloudpickle` and asserting `isinstance` after the round-trip — the call path that actually trips the bug under `cloudpickle`.

Bumps version 0.3.9 -> 0.3.10.

Fixes #390.