### PR TITLE
fix(lib): import_hook now correctly handles `@no_type_check` decorator

### DIFF
--- a/jaxtyping/_import_hook.py
+++ b/jaxtyping/_import_hook.py
@@ -82,8 +82,9 @@ def _optimized_cache_from_source(typechecker_hash, /, path, debug_override=None)
     #    double-decorators.
     # Version 9: Now reporting the correct source code lines. (Important when used with
     #    a debugger.)
+    # Version 10: Now respecting `@no_type_check` in the import hook.
     return cache_from_source(
-        path, debug_override, optimization=f"jaxtyping9{typechecker_hash}"
+        path, debug_override, optimization=f"jaxtyping10{typechecker_hash}"
     )
 
 
@@ -134,10 +135,21 @@ class Typechecker:
         )
 
 
+def _is_no_type_check(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == "no_type_check"
+    elif isinstance(node, ast.Attribute):
+        return node.attr == "no_type_check"
+    elif isinstance(node, ast.Call):
+        return _is_no_type_check(node.func)
+    return False
+
+
 class JaxtypingTransformer(ast.NodeVisitor):
     def __init__(self, *, typechecker: Typechecker) -> None:
         self._parents: list[ast.AST] = []
         self._typechecker = typechecker
+        self._no_type_check_level = 0
 
     def visit_Module(self, node: ast.Module):
         # Insert "import jaxtyping" after any "from __future__ ..." imports
@@ -156,14 +168,23 @@ class JaxtypingTransformer(ast.NodeVisitor):
         return node
 
     def visit_ClassDef(self, node: ast.ClassDef):
-        # Place at the start of the decorator list, so that `@dataclass` decorators get
-        # called first.
-        decorator = self._typechecker.get_ast()
-        ast.copy_location(decorator, node)
-        node.decorator_list.insert(0, decorator)
+        has_no_type_check = any(_is_no_type_check(d) for d in node.decorator_list)
+        if has_no_type_check:
+            self._no_type_check_level += 1
+
+        if self._no_type_check_level == 0:
+            # Place at the start of the decorator list, so that `@dataclass` decorators
+            # get called first.
+            decorator = self._typechecker.get_ast()
+            ast.copy_location(decorator, node)
+            node.decorator_list.insert(0, decorator)
+
         self._parents.append(node)
         self.generic_visit(node)
         self._parents.pop()
+
+        if has_no_type_check:
+            self._no_type_check_level -= 1
         return node
 
     def visit_FunctionDef(self, node: ast.FunctionDef):
@@ -174,27 +195,35 @@ class JaxtypingTransformer(ast.NodeVisitor):
         # had type annotations in the body of the function (or
         # `assert isinstance(..., SomeType)`).
 
-        decorator = self._typechecker.get_ast()
-        ast.copy_location(decorator, node)
-        # Place at the end of the decorator list, because:
-        # - as otherwise we wrap e.g. `jax.custom_{jvp,vjp}` and lose the ability
-        #     to `defjvp` etc.
-        # - decorators frequently remove annotations from functions, and we'd like
-        #     to use those annotations.
-        # - typeguard in particular wants to be at the end of the decorator list, as
-        #     it works by recompling the wrapped function.
-        #
-        # Note that the counter-argument here is that we'd like to place this
-        # at the start of the decorator list, in case a typechecking annotation
-        # has been manually applied, and we'd need to be above that. In this
-        # case we're just going to have to need to ask the user to remove their
-        # typechecking annotation (and let this decorator do it instead).
-        # It's more important we be compatible with normal JAX code.
-        node.decorator_list.append(decorator)
+        has_no_type_check = any(_is_no_type_check(d) for d in node.decorator_list)
+        if has_no_type_check:
+            self._no_type_check_level += 1
+
+        if self._no_type_check_level == 0:
+            decorator = self._typechecker.get_ast()
+            ast.copy_location(decorator, node)
+            # Place at the end of the decorator list, because:
+            # - as otherwise we wrap e.g. `jax.custom_{jvp,vjp}` and lose the ability
+            #     to `defjvp` etc.
+            # - decorators frequently remove annotations from functions, and we'd like
+            #     to use those annotations.
+            # - typeguard in particular wants to be at the end of the decorator list, as
+            #     it works by recompling the wrapped function.
+            #
+            # Note that the counter-argument here is that we'd like to place this
+            # at the start of the decorator list, in case a typechecking annotation
+            # has been manually applied, and we'd need to be above that. In this
+            # case we're just going to have to need to ask the user to remove their
+            # typechecking annotation (and let this decorator do it instead).
+            # It's more important we be compatible with normal JAX code.
+            node.decorator_list.append(decorator)
 
         self._parents.append(node)
         self.generic_visit(node)
         self._parents.pop()
+
+        if has_no_type_check:
+            self._no_type_check_level -= 1
         return node
 
 

--- a/test/import_hook_tester.py
+++ b/test/import_hook_tester.py
@@ -18,6 +18,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import dataclasses
+from functools import wraps
 from typing import no_type_check
 
 import equinox as eqx
@@ -252,6 +253,83 @@ def f(_: Float32[jnp.ndarray, "foo bar"]):
 
 
 f("not an array")
+
+
+# The following classes simulate type hints like `wp.array[wp.vec3]` from the `warp
+#  library. `CustomType[int]` evaluates at runtime to an instance of `CustomGeneric`
+#  via `__class_getitem__`. According to PEP 484 and standard typing rules, raw
+# instances of classes (unless wrapped in typing constructs like `Literal` or
+# `Annotated`) are not PEP-compliant type hints. Under the import hook, if
+# `@no_type_check` is not respected, decorators like `@jaxtyped` would try to apply
+# typecheckers (e.g. `beartype` or `typeguard`) to functions annotated with these
+# PEP-noncompliant instances, causing typecheckers to crash at decoration time.
+class CustomGeneric:
+    def __init__(self, arg):
+        self.arg = arg
+
+    def __repr__(self):
+        return f"CustomGeneric({self.arg})"
+
+
+class CustomType:
+    def __class_getitem__(cls, item):
+        return CustomGeneric(item)
+
+
+@no_type_check
+def invalid_hint_func(x: CustomType[int]):
+    pass
+
+
+invalid_hint_func(None)
+
+
+@no_type_check
+class InvalidHintClass:
+    def method(self, x: CustomType[int]):
+        pass
+
+
+InvalidHintClass().method(None)
+
+
+def dummy_decorator(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+@dummy_decorator
+@no_type_check
+@dummy_decorator
+def decorated_func(x: CustomType[int]):
+    pass
+
+
+decorated_func(None)
+
+
+@no_type_check
+def outer_func():
+    def inner_func(x: CustomType[int]):
+        pass
+
+    inner_func(None)
+
+
+outer_func()
+
+
+@no_type_check
+class OuterClass:
+    class InnerClass:
+        def method(self, x: CustomType[int]):
+            pass
+
+
+OuterClass.InnerClass().method(None)
 
 
 # Record that we've finished our checks successfully


### PR DESCRIPTION
Hi!

I recently decided to use NVIDIA's warp-lang package for performance reason, and noticed that `beartype` would complain that `warp`'s type hints are not PEP-compliant. I then tried  to put a `@no_type_check` decorator, but it didn't fix the error.

After some investigation, it appears that this bug is caused by the import hook mechanism implemented by `jaxtyping`. Fixing it was relatively easy :-)

You can run a MWE with `uv run mwe.py`.

`mwe.py`:

```python
# /// script
# requires-python = ">=3.11"
# dependencies = [
#     "beartype>=0.22.9",
#     "jaxtyping",
#     "warp-lang>=1.14.0",
# ]
#
# [tool.uv.sources]
# jaxtyping = { path = ".", editable = true }
# ///
from jaxtyping import install_import_hook

with install_import_hook("warp_example", "beartype.beartype"):
    from warp_example import foo

    print(foo)
```

`warp_example.py`
```python
import warp as wp
from typing import no_type_check


@no_type_check
@wp.kernel
def foo(x: wp.array[wp.vec3], y: wp.array[float]) -> None:
    tid = wp.tid()
    x[tid] = y[tid] + 1
```